### PR TITLE
Read hashReserved from disk instead of assuming 0, to avoid sync issues

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -304,6 +304,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->hashAnchor     = diskindex.hashAnchor;
                 pindexNew->nVersion       = diskindex.nVersion;
                 pindexNew->hashMerkleRoot = diskindex.hashMerkleRoot;
+                pindexNew->hashReserved   = diskindex.hashReserved;
                 pindexNew->nTime          = diskindex.nTime;
                 pindexNew->nBits          = diskindex.nBits;
                 pindexNew->nNonce         = diskindex.nNonce;


### PR DESCRIPTION
Zcash upstream issue: https://github.com/zcash/zcash/pull/2931

ZEN, HUSH, KMD, BTCZ and many other Equihash coins have dealt with the same issue, which happens when BTG mining software is used on other Equihash coins, that puts a block height in for hashReserved instead of 0.