### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Installing
 
 Compiled binaries can be found in ./src directory. Copy them to your working path:
 
-    cp ./src/votecoin-cli /usr/bin
-    cp ./src/votecoind /usr/bin
-    cp ./zcutil/vot /usr/bin
+    cp ./src/votecoin-cli /usr/local/bin
+    cp ./src/votecoind /usr/local/bin
+    cp ./zcutil/vot /usr/local/bin
 
 
 Running


### PR DESCRIPTION
Changed installation paths for `votecoin-cli`, `votecoind`, `vot`.
Based on standard execution file placements on *nix systems ([reference](https://unix.stackexchange.com/questions/8656/usr-bin-vs-usr-local-bin-on-linux/8663)).